### PR TITLE
Fixed build for mingw

### DIFF
--- a/noc_file_dialog.h
+++ b/noc_file_dialog.h
@@ -134,7 +134,8 @@ const char *noc_file_dialog_open(int flags,
 
 #ifdef NOC_FILE_DIALOG_WIN32
 
-#include "Commdlg.h"
+#include <windows.h>
+#include <commdlg.h>
 
 const char *noc_file_dialog_open(int flags,
                                  const char *filters,


### PR DESCRIPTION
For some reason, mingw's version of commdlg.h doesn't include windows.h, so I placed it before the include and made it lowercase since some filesystems are case sensitive.

(Thanks for this great library by the way. I prefer much better than tinyfiledialogs and nativefiledialog since it's way less bloated and has the easiest "build system" ever.)