### PR TITLE
Fix win32 noc_file_dialog_open

### DIFF
--- a/noc_file_dialog.h
+++ b/noc_file_dialog.h
@@ -160,16 +160,21 @@ const char *noc_file_dialog_open(int flags,
     char szFile[260];       // buffer for file name
     int ret;
 
+    // init default file name
+    if (default_name)
+        strncpy(szFile, default_name, sizeof(szFile) - 1);
+    else
+        szFile[0] = '\0';
+
     ZeroMemory(&ofn, sizeof(ofn));
     ofn.lStructSize = sizeof(ofn);
     ofn.lpstrFile = szFile;
-    ofn.lpstrFile[0] = '\0';
     ofn.nMaxFile = sizeof(szFile);
     ofn.lpstrFilter = filters;
     ofn.nFilterIndex = 1;
     ofn.lpstrFileTitle = NULL;
     ofn.nMaxFileTitle = 0;
-    ofn.lpstrInitialDir = NULL;
+    ofn.lpstrInitialDir = (LPSTR)default_path;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
     if (flags & NOC_FILE_DIALOG_OPEN)

--- a/noc_file_dialog.h
+++ b/noc_file_dialog.h
@@ -175,7 +175,7 @@ const char *noc_file_dialog_open(int flags,
     ofn.lpstrFileTitle = NULL;
     ofn.nMaxFileTitle = 0;
     ofn.lpstrInitialDir = (LPSTR)default_path;
-    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
 
     if (flags & NOC_FILE_DIALOG_OPEN)
         ret = GetOpenFileName(&ofn);


### PR DESCRIPTION
Use default path name, default directory.

Prevent GetOpenFileName/GetSaveFileName from setting the working directory with OFN_NOCHANGEDIR.