### PR TITLE
noc_file_dialog: fix win32 noc_file_dialog_open not using OVERWRITEPR…

### DIFF
--- a/noc_file_dialog.h
+++ b/noc_file_dialog.h
@@ -177,13 +177,16 @@ const char *noc_file_dialog_open(int flags,
     ofn.lpstrInitialDir = (LPSTR)default_path;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
 
+    if (flags & NOC_FILE_DIALOG_OVERWRITE_CONFIRMATION)
+        ofn.Flags |= OFN_OVERWRITEPROMPT;
+
     if (flags & NOC_FILE_DIALOG_OPEN)
         ret = GetOpenFileName(&ofn);
     else
         ret = GetSaveFileName(&ofn);
 
     free(g_noc_file_dialog_ret);
-    g_noc_file_dialog_ret = ret ? strdup(szFile) : NULL;
+    g_noc_file_dialog_ret = ret ? _strdup(szFile) : NULL;
     return g_noc_file_dialog_ret;
 }
 


### PR DESCRIPTION
```NOC_FILE_DIALOG_OVERWRITE_CONFIRMATION``` was not being respected by the win32 version.
Now ```OFN_OVERWRITEPROMPT``` is set, if ```NOC_FILE_DIALOG_OVERWRITE_CONFIRMATION``` was set by the user.

Also, ```strdup``` is deprecated on MSVC and instead ```_strdup``` should be used.
Otherwise cl.exe will warn on higher warning levels:

```
C:\code\games\shared\extern/noc_file_dialog.h(189): warning C4996: 'strdup': The POSIX name for this item is deprecate d. Instead, use the ISO C and C++ conformant name: _strdup. See online help for details.
```

In this kind of "drop in and forget" library it's probably better to not generate a lot of warnings.