### PR TITLE
noc_file_dialog: Specify timestamp to focus dialog for GTK

### DIFF
--- a/noc_file_dialog.h
+++ b/noc_file_dialog.h
@@ -78,6 +78,10 @@ static char *g_noc_file_dialog_ret = NULL;
 
 #include <gtk/gtk.h>
 
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
 const char *noc_file_dialog_open(int flags,
                                  const char *filters,
                                  const char *default_path,
@@ -132,6 +136,16 @@ const char *noc_file_dialog_open(int flags,
         filters += strlen(filters) + 1;
     }
 
+    gtk_widget_show_all(dialog);
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_DISPLAY(gdk_display_get_default())) {
+        GdkWindow *window = gtk_widget_get_window(dialog);
+        gdk_window_set_events(window,
+            gdk_window_get_events(window) | GDK_PROPERTY_CHANGE_MASK);
+        gtk_window_present_with_time(GTK_WINDOW(dialog),
+            gdk_x11_get_server_time(window));
+    }
+#endif
     res = gtk_dialog_run(GTK_DIALOG(dialog));
 
     free(g_noc_file_dialog_ret);


### PR DESCRIPTION
GNOME has a "focus stealing prevention" feature that will open new windows in the background to prevent the keyboard focus from being stolen from a user, and show an "&lt;Application&gt; is ready" notification.

This feature currently impacts file dialog creation resulting in the dialog being confusingly spawned in the background on every creation after the first with the GTK implementation.

This patch adds a call to `gtk_window_present_with_time()` with the current time, enforcing that the dialog always makes it to the top of the window stacking order and receives focus.

I believe this is the simplest/best way to handle this for my application of responding to a button click without convenient access to this necessary event token/timestamp, but I welcome someone with more experience with GTK to weigh in here with a better solution. Note that I've not tested with Wayland.

Some information about the issue/feature:
* https://gitlab.gnome.org/GNOME/mutter/issues/673
* https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/358
* An [example solution from network-manager-applet](https://gitlab.gnome.org/GNOME/network-manager-applet/-/blob/5b65de43675eeb5c3e59ae27c013c892c29896ed/src/applet-dialogs.c#L1100)
* Another [example solution from chromium UI](https://chromium.googlesource.com/chromium/src/+/a726ff8f85b8138c2245ec1fd5aa71aaa0a8deba/chrome/browser/ui/libgtkui/select_file_dialog_impl_gtk.cc#194)

Tagging other, similar projects I came across while searching for solutions which might be interested in this:
* https://github.com/mlabbe/nativefiledialog/issues/79
* https://github.com/gkngkc/UnityStandaloneFileBrowser/issues/49